### PR TITLE
Github  LICENSE.txt convention added

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,3 @@
+All graphics and documentation in this project are licensed under
+Creative Commons Attribution-ShareALike 3.0 Unported.
+See http://creativecommons.org/licenses/by-sa/3.0/ for the full description.


### PR DESCRIPTION
Currently, README indicates this work is licensed under CC by SA, however adding LICENSE.txt both serves to clarify which spoecific CCbySA version and conforms to GitHub conventions... which is just nice for everyone ;)

Note, this is the same version of CCbySA as Fritzing is distributed under.